### PR TITLE
Always send client ID

### DIFF
--- a/Chat/Network.cs
+++ b/Chat/Network.cs
@@ -424,12 +424,12 @@ namespace Chat
                 return;
             }
 
-            string clientId = "";
+            string clientId = "-1";
             if (FrmHolder.clientId != -1)
             {
-                clientId = $" {Convert.ToString(FrmHolder.clientId)}";
+                clientId = $"{Convert.ToString(FrmHolder.clientId)}";
             }
-            SendMessage(connectedClients[0], ComposeMessage(connectedClients[0], -1, 0, $"{FrmHolder.username}{clientId}", null));
+            SendMessage(connectedClients[0], ComposeMessage(connectedClients[0], -1, 0, $"{FrmHolder.username} {clientId}", null));
         }
 
         public void ServerAcceptIncomingConnection(TcpListener tcpListener)

--- a/Chat/frmChatScreen.cs
+++ b/Chat/frmChatScreen.cs
@@ -92,12 +92,12 @@ namespace Chat
 #endif
             }
 
-            if (e.message.messageType == 0) // Connection Request [username, clientId (if reconnecting)]
+            if (e.message.messageType == 0) // Connection Request [username, clientId]
             {
                 string[] parts = e.message.messageText.Split(' ', 2);
                 string username = parts[0];
                 int clientId = -1;
-                if (parts.Length > 1)
+                if (parts[1] != "-1")
                 {
                     clientId = Convert.ToInt32(parts[1]);
                 }


### PR DESCRIPTION
If the clientID is not sent every time, even if the client doesn't know its own client ID yet, then it will be harder to split other variables from the connection request string.

Send the client ID every time. Set it to -1 if the client doesn't know its client ID yet.