### PR TITLE
Inform client when the message queue has been fully sent

### DIFF
--- a/Chat/Network.cs
+++ b/Chat/Network.cs
@@ -275,6 +275,7 @@ namespace Chat
             else
             {
                 client.sendingMessageQueue = false;
+                SendMessage(client, ComposeMessage(client, -1, 31, null, null));
                 if (FrmHolder.hosting == false)
                 {
                     SendMessage(client, ComposeMessage(client, -1, 18, null, null));

--- a/Chat/frmChatScreen.cs
+++ b/Chat/frmChatScreen.cs
@@ -302,6 +302,10 @@ namespace Chat
             {
                 e.client.connectionSetupComplete = true;
             }
+            else if (e.message.messageType == 31) // Finished sending message queue
+            {
+                e.client.receivingMessageQueue = false;
+            }
         }
 
         private void ClearClientList()


### PR DESCRIPTION
The client never knows when the server has finished sending its message queue, which may result in some messages not being received and the connection becoming effectively unusable.

Inform the client when the message queue has been fully sent.

Closes #32.