### PR TITLE
Develop feat #42 use enumeration for message types

### DIFF
--- a/Chat/Client.cs
+++ b/Chat/Client.cs
@@ -72,7 +72,7 @@ namespace Chat
         public byte[] typeBuffer = new byte[4];
         public byte[] lengthBuffer = new byte[4];
         public uint? messageId = null;
-        public uint? messageType = null;
+        public Message.MessageTypes messageType = Message.MessageTypes.None;
         public uint? messageLength = null;
         public bool readHeader = false;
 

--- a/Chat/Message.cs
+++ b/Chat/Message.cs
@@ -8,6 +8,42 @@ namespace Chat
 {
     public class Message
     {
+        public enum MessageTypes : uint
+        {
+            ConnectionRequest = 0,
+            Acknowledgement = 1,
+            ChatMessage = 2,
+            ClientDisconnect = 3,
+            UsernameInUse = 4,
+            UserConnected = 5,
+            UserDisconnected = 6,
+            ClearUserList = 7,
+            AddToUserList = 8,
+            Kicked = 9,
+            OtherUserKicked = 10,
+            Heartbeat = 11,
+            OwnClientId = 12,
+            OtherUserLostConnection = 13,
+            MadeAdmin = 14,
+            OtherUserMadeAdmin = 15,
+            RemovedAdmin = 16,
+            OtherUserRemovedAdmin = 17,
+            SendMessageQueue = 18,
+            ConnectionSetupComplete = 19,
+            ClientId = 20,
+            RequestVersionNumber = 21,
+            ClientVersionNumber = 22,
+            RequestUsername = 23,
+            ClientUsername = 24,
+            RequestClientId = 25,
+            ServersMinimumSupportedClientVersionNumber = 26,
+            ServersMaximumSupportedClientVersionNumber = 27,
+            ServersPreReleaseSupport = 28,
+            ServerVersionNumberCompatibility = 29,
+            ServerVersionNumber = 30,
+            FinishedSendingMessageQueue = 31
+        }
+
         public uint messageId;
         public uint messageType;
         public string messageText;
@@ -95,19 +131,19 @@ namespace Chat
 
         public void MessageTextToOrFromBytes()
         {
-                if (messageText != null && messageBytes == null)
-                {
-                    messageBytes = Encoding.Unicode.GetBytes(messageText);
-                }
-                else if (messageBytes != null && CheckIfCanConvertToText())
-                {
-                    messageText = Encoding.Unicode.GetString(messageBytes);
-                }
+            if (messageText != null && messageBytes == null)
+            {
+                messageBytes = Encoding.Unicode.GetBytes(messageText);
+            }
+            else if (messageBytes != null && CheckIfCanConvertToText())
+            {
+                messageText = Encoding.Unicode.GetString(messageBytes);
+            }
         }
 
         public void SetPriorityLevelFromMessageType()
         {
-            switch(messageType)
+            switch (messageType)
             {
                 case 0: messageSendPriority = 0; break;
                 case 1: messageSendPriority = 0; break;

--- a/Chat/Message.cs
+++ b/Chat/Message.cs
@@ -45,13 +45,13 @@ namespace Chat
         }
 
         public uint messageId;
-        public uint messageType;
+        public MessageTypes messageType;
         public string messageText;
         public byte[] messageBytes;
 
         public int messageSendPriority;
 
-        public Message(uint messageId, uint messageType, string messageText)
+        public Message(uint messageId, MessageTypes messageType, string messageText)
         {
             this.messageId = messageId;
             this.messageType = messageType;
@@ -61,7 +61,7 @@ namespace Chat
             SetPriorityLevelFromMessageType();
         }
 
-        public Message(uint messageType, string messageText)
+        public Message(MessageTypes messageType, string messageText)
         {
             this.messageType = messageType;
             this.messageText = messageText;
@@ -71,7 +71,7 @@ namespace Chat
 
         }
 
-        public Message(uint messageId, uint messageType, string messageText, int messageSendPriority)
+        public Message(uint messageId, MessageTypes messageType, string messageText, int messageSendPriority)
         {
             this.messageId = messageId;
             this.messageType = messageType;
@@ -81,7 +81,7 @@ namespace Chat
             this.messageSendPriority = messageSendPriority;
         }
 
-        public Message(uint messageType, string messageText, int messageSendPriority)
+        public Message(MessageTypes messageType, string messageText, int messageSendPriority)
         {
             this.messageType = messageType;
             this.messageText = messageText;
@@ -90,7 +90,7 @@ namespace Chat
             this.messageSendPriority = messageSendPriority;
         }
 
-        public Message(uint messageId, uint messageType, byte[] messageBytes)
+        public Message(uint messageId, MessageTypes messageType, byte[] messageBytes)
         {
             this.messageId = messageId;
             this.messageType = messageType;
@@ -100,7 +100,7 @@ namespace Chat
             SetPriorityLevelFromMessageType();
         }
 
-        public Message(uint messageType, byte[] messageBytes)
+        public Message(MessageTypes messageType, byte[] messageBytes)
         {
             this.messageType = messageType;
             this.messageBytes = messageBytes;
@@ -110,7 +110,7 @@ namespace Chat
 
         }
 
-        public Message(uint messageId, uint messageType, byte[] messageBytes, int messageSendPriority)
+        public Message(uint messageId, MessageTypes messageType, byte[] messageBytes, int messageSendPriority)
         {
             this.messageId = messageId;
             this.messageType = messageType;
@@ -120,7 +120,7 @@ namespace Chat
             this.messageSendPriority = messageSendPriority;
         }
 
-        public Message(uint messageType, byte[] messageBytes, int messageSendPriority)
+        public Message(MessageTypes messageType, byte[] messageBytes, int messageSendPriority)
         {
             this.messageType = messageType;
             this.messageBytes = messageBytes;
@@ -145,38 +145,38 @@ namespace Chat
         {
             switch (messageType)
             {
-                case 0: messageSendPriority = 0; break;
-                case 1: messageSendPriority = 0; break;
-                case 2: messageSendPriority = 1; break;
-                case 3: messageSendPriority = 0; break;
-                case 4: messageSendPriority = 0; break;
-                case 5: messageSendPriority = 1; break;
-                case 6: messageSendPriority = 1; break;
-                case 7: messageSendPriority = 1; break;
-                case 8: messageSendPriority = 1; break;
-                case 9: messageSendPriority = 0; break;
-                case 10: messageSendPriority = 1; break;
-                case 11: messageSendPriority = 0; break;
-                case 12: messageSendPriority = 0; break;
-                case 13: messageSendPriority = 1; break;
-                case 14: messageSendPriority = 1; break;
-                case 15: messageSendPriority = 1; break;
-                case 16: messageSendPriority = 1; break;
-                case 17: messageSendPriority = 1; break;
-                case 18: messageSendPriority = 0; break;
-                case 19: messageSendPriority = 0; break;
-                case 20: messageSendPriority = 0; break;
-                case 21: messageSendPriority = 0; break;
-                case 22: messageSendPriority = 0; break;
-                case 23: messageSendPriority = 0; break;
-                case 24: messageSendPriority = 0; break;
-                case 25: messageSendPriority = 0; break;
-                case 26: messageSendPriority = 0; break;
-                case 27: messageSendPriority = 0; break;
-                case 28: messageSendPriority = 0; break;
-                case 29: messageSendPriority = 0; break;
-                case 30: messageSendPriority = 0; break;
-                case 31: messageSendPriority = 0; break;
+                case MessageTypes.ConnectionRequest: messageSendPriority = 0; break;
+                case MessageTypes.Acknowledgement: messageSendPriority = 0; break;
+                case MessageTypes.ChatMessage: messageSendPriority = 1; break;
+                case MessageTypes.ClientDisconnect: messageSendPriority = 0; break;
+                case MessageTypes.UsernameInUse: messageSendPriority = 0; break;
+                case MessageTypes.UserConnected: messageSendPriority = 1; break;
+                case MessageTypes.UserDisconnected: messageSendPriority = 1; break;
+                case MessageTypes.ClearUserList: messageSendPriority = 1; break;
+                case MessageTypes.AddToUserList: messageSendPriority = 1; break;
+                case MessageTypes.Kicked: messageSendPriority = 0; break;
+                case MessageTypes.OtherUserKicked: messageSendPriority = 1; break;
+                case MessageTypes.Heartbeat: messageSendPriority = 0; break;
+                case MessageTypes.OwnClientId: messageSendPriority = 0; break;
+                case MessageTypes.OtherUserLostConnection: messageSendPriority = 1; break;
+                case MessageTypes.MadeAdmin: messageSendPriority = 1; break;
+                case MessageTypes.OtherUserMadeAdmin: messageSendPriority = 1; break;
+                case MessageTypes.RemovedAdmin: messageSendPriority = 1; break;
+                case MessageTypes.OtherUserRemovedAdmin: messageSendPriority = 1; break;
+                case MessageTypes.SendMessageQueue: messageSendPriority = 0; break;
+                case MessageTypes.ConnectionSetupComplete: messageSendPriority = 0; break;
+                case MessageTypes.ClientId: messageSendPriority = 0; break;
+                case MessageTypes.RequestVersionNumber: messageSendPriority = 0; break;
+                case MessageTypes.ClientVersionNumber: messageSendPriority = 0; break;
+                case MessageTypes.RequestUsername: messageSendPriority = 0; break;
+                case MessageTypes.ClientUsername: messageSendPriority = 0; break;
+                case MessageTypes.RequestClientId: messageSendPriority = 0; break;
+                case MessageTypes.ServersMinimumSupportedClientVersionNumber: messageSendPriority = 0; break;
+                case MessageTypes.ServersMaximumSupportedClientVersionNumber: messageSendPriority = 0; break;
+                case MessageTypes.ServersPreReleaseSupport: messageSendPriority = 0; break;
+                case MessageTypes.ServerVersionNumberCompatibility: messageSendPriority = 0; break;
+                case MessageTypes.ServerVersionNumber: messageSendPriority = 0; break;
+                case MessageTypes.FinishedSendingMessageQueue: messageSendPriority = 0; break;
                 default: messageSendPriority = 0; break;
             }
         }
@@ -185,38 +185,38 @@ namespace Chat
         {
             switch (messageType)
             {
-                case 0: return true;
-                case 1: return true;
-                case 2: return true;
-                case 3: return true;
-                case 4: return true;
-                case 5: return true;
-                case 6: return true;
-                case 7: return true;
-                case 8: return true;
-                case 9: return true;
-                case 10: return true;
-                case 11: return true;
-                case 12: return true;
-                case 13: return true;
-                case 14: return true;
-                case 15: return true;
-                case 16: return true;
-                case 17: return true;
-                case 18: return true;
-                case 19: return true;
-                case 20: return true;
-                case 21: return true;
-                case 22: return true;
-                case 23: return true;
-                case 24: return true;
-                case 25: return true;
-                case 26: return true;
-                case 27: return true;
-                case 28: return true;
-                case 29: return true;
-                case 30: return true;
-                case 31: return true;
+                case MessageTypes.ConnectionRequest: return true;
+                case MessageTypes.Acknowledgement: return true;
+                case MessageTypes.ChatMessage: return true;
+                case MessageTypes.ClientDisconnect: return true;
+                case MessageTypes.UsernameInUse: return true;
+                case MessageTypes.UserConnected: return true;
+                case MessageTypes.UserDisconnected: return true;
+                case MessageTypes.ClearUserList: return true;
+                case MessageTypes.AddToUserList: return true;
+                case MessageTypes.Kicked: return true;
+                case MessageTypes.OtherUserKicked: return true;
+                case MessageTypes.Heartbeat: return true;
+                case MessageTypes.OwnClientId: return true;
+                case MessageTypes.OtherUserLostConnection: return true;
+                case MessageTypes.MadeAdmin: return true;
+                case MessageTypes.OtherUserMadeAdmin: return true;
+                case MessageTypes.RemovedAdmin: return true;
+                case MessageTypes.OtherUserRemovedAdmin: return true;
+                case MessageTypes.SendMessageQueue: return true;
+                case MessageTypes.ConnectionSetupComplete: return true;
+                case MessageTypes.ClientId: return true;
+                case MessageTypes.RequestVersionNumber: return true;
+                case MessageTypes.ClientVersionNumber: return true;
+                case MessageTypes.RequestUsername: return true;
+                case MessageTypes.ClientUsername: return true;
+                case MessageTypes.RequestClientId: return true;
+                case MessageTypes.ServersMinimumSupportedClientVersionNumber: return true;
+                case MessageTypes.ServersMaximumSupportedClientVersionNumber: return true;
+                case MessageTypes.ServersPreReleaseSupport: return true;
+                case MessageTypes.ServerVersionNumberCompatibility: return true;
+                case MessageTypes.ServerVersionNumber: return true;
+                case MessageTypes.FinishedSendingMessageQueue: return true;
                 default: return false;
             }
         }

--- a/Chat/Message.cs
+++ b/Chat/Message.cs
@@ -10,7 +10,7 @@ namespace Chat
     {
         public enum MessageTypes : uint
         {
-            ConnectionRequest = 0,
+            None = 0,
             Acknowledgement = 1,
             ChatMessage = 2,
             ClientDisconnect = 3,
@@ -145,7 +145,7 @@ namespace Chat
         {
             switch (messageType)
             {
-                case MessageTypes.ConnectionRequest: messageSendPriority = 0; break;
+                case MessageTypes.None: messageSendPriority = 0; break;
                 case MessageTypes.Acknowledgement: messageSendPriority = 0; break;
                 case MessageTypes.ChatMessage: messageSendPriority = 1; break;
                 case MessageTypes.ClientDisconnect: messageSendPriority = 0; break;
@@ -185,7 +185,7 @@ namespace Chat
         {
             switch (messageType)
             {
-                case MessageTypes.ConnectionRequest: return true;
+                case MessageTypes.None: return true;
                 case MessageTypes.Acknowledgement: return true;
                 case MessageTypes.ChatMessage: return true;
                 case MessageTypes.ClientDisconnect: return true;

--- a/Chat/frmChatScreen.cs
+++ b/Chat/frmChatScreen.cs
@@ -80,7 +80,7 @@ namespace Chat
                 }
             }
 #endif
-            if (e.message.messageType != 1 && e.message.messageType != 3 && e.message.messageType != 11)
+            if (e.message.messageType != Message.MessageTypes.Acknowledgement && e.message.messageType != Message.MessageTypes.ClientDisconnect && e.message.messageType != Message.MessageTypes.Heartbeat)
             {
                 network.BeginWrite(e.client, network.ComposeMessage(e.client, e.message.messageId, 1, null, null)); // Acknowledge received message
                 if (e.client.connectionSetupComplete)
@@ -96,11 +96,11 @@ namespace Chat
                 e.client.messagesReceived.Add(e.message);
             }
 
-            if (e.message.messageType == 0) // Connection Request [username, clientId, version number]
+            if (e.message.messageType == Message.MessageTypes.ConnectionRequest)
             {
 
             }
-            else if (e.message.messageType == 1) // Message Acknowledgement
+            else if (e.message.messageType == Message.MessageTypes.Acknowledgement)
             {
                 foreach (Message item in e.client.messagesToBeSent)
                 {
@@ -116,7 +116,7 @@ namespace Chat
                     network.SendFirstMessageInMessageQueue(e.client);
                 }
             }
-            else if (e.message.messageType == 2) // Message recieve [username, message]
+            else if (e.message.messageType == Message.MessageTypes.ChatMessage)
             {
                 string[] parts = e.message.messageText.Split(' ', 2);
                 string username = parts[0];
@@ -127,7 +127,7 @@ namespace Chat
                     network.SendToAll(null, 2, e.message.messageText, null);
                 }
             }
-            else if (e.message.messageType == 3) // Disconnect
+            else if (e.message.messageType == Message.MessageTypes.ClientDisconnect)
             {
                 if (FrmHolder.hosting)
                 {
@@ -153,29 +153,29 @@ namespace Chat
                     OpenMainMenu();
                 }
             }
-            else if (e.message.messageType == 4) // Username already used
+            else if (e.message.messageType == Message.MessageTypes.UsernameInUse)
             {
                 network.clientCancellationTokenSource.Cancel();
                 MessageBox.Show("This username is already in use", "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 OpenMainMenu();
             }
-            else if (e.message.messageType == 5) // Client connected
+            else if (e.message.messageType == Message.MessageTypes.UserConnected)
             {
                 PrintChatMessage($"{e.message.messageText} connected");
             }
-            else if (e.message.messageType == 6) // Client disconnected
+            else if (e.message.messageType == Message.MessageTypes.UserDisconnected)
             {
                 PrintChatMessage($"{e.message.messageText} disconnected");
             }
-            else if (e.message.messageType == 7) // Clear user list
+            else if (e.message.messageType == Message.MessageTypes.ClearUserList)
             {
                 xlsvConnectedUsers.Items.Clear();
             }
-            else if (e.message.messageType == 8) // Add to user list
+            else if (e.message.messageType == Message.MessageTypes.AddToUserList)
             {
                 xlsvConnectedUsers.Items.Add(e.message.messageText);
             }
-            else if (e.message.messageType == 9) // Kicked
+            else if (e.message.messageType == Message.MessageTypes.Kicked)
             {
                 if (network.clientThread != null && network.clientThread.IsAlive)
                 {
@@ -195,7 +195,7 @@ namespace Chat
                 }
                 OpenMainMenu();
             }
-            else if (e.message.messageType == 10) // Another client kicked
+            else if (e.message.messageType == Message.MessageTypes.OtherUserKicked)
             {
                 string[] parts = e.message.messageText.Split(' ', 3);
                 string username = parts[0];
@@ -211,54 +211,54 @@ namespace Chat
                     PrintChatMessage($"{username} was kicked by {kickerUsername}");
                 }
             }
-            else if (e.message.messageType == 11) // Heartbeat
+            else if (e.message.messageType == Message.MessageTypes.Heartbeat)
             {
                 if (FrmHolder.hosting)
                 {
                     network.BeginWrite(e.client, network.ComposeMessage(e.client, 0, 11, null, null));
                 }
             }
-            else if (e.message.messageType == 12) // Set clientId
+            else if (e.message.messageType == Message.MessageTypes.OwnClientId)
             {
                 FrmHolder.clientId = Convert.ToUInt32(e.message.messageText);
             }
-            else if (e.message.messageType == 13) // Another client heartbeat failed
+            else if (e.message.messageType == Message.MessageTypes.OtherUserLostConnection)
             {
                 PrintChatMessage($"{e.message.messageText} has lost connection...");
             }
-            else if (e.message.messageType == 14) // Made admin
+            else if (e.message.messageType == Message.MessageTypes.MadeAdmin)
             {
                 PrintChatMessage($"You have been made an Admin by {e.message.messageText}");
             }
-            else if (e.message.messageType == 15) // Another made admin
+            else if (e.message.messageType == Message.MessageTypes.OtherUserMadeAdmin)
             {
                 string[] parts = e.message.messageText.Split(' ', 2);
                 string username = parts[0];
                 string setterUsername = parts[1];
                 PrintChatMessage($"{username} has been made an Admin by {setterUsername}");
             }
-            else if (e.message.messageType == 16) // Removed admin
+            else if (e.message.messageType == Message.MessageTypes.RemovedAdmin)
             {
                 PrintChatMessage($"You have been removed from Admin by {e.message.messageText}");
             }
-            else if (e.message.messageType == 17) // Another removed admin
+            else if (e.message.messageType == Message.MessageTypes.OtherUserRemovedAdmin)
             {
                 string[] parts = e.message.messageText.Split(' ', 2);
                 string username = parts[0];
                 string setterUsername = parts[1];
                 PrintChatMessage($"{username} has been removed from Admin by {setterUsername}");
             }
-            else if (e.message.messageType == 18) // Send message queue
+            else if (e.message.messageType == Message.MessageTypes.SendMessageQueue)
             {
                 e.client.sendingMessageQueue = true;
                 e.client.receivingMessageQueue = false;
                 network.SendFirstMessageInMessageQueue(e.client);
             }
-            else if (e.message.messageType == 19) // Connection setup complete
+            else if (e.message.messageType == Message.MessageTypes.ConnectionSetupComplete)
             {
                 e.client.connectionSetupComplete = true;
             }
-            else if (e.message.messageType == 20) // Receive client clients ID
+            else if (e.message.messageType == Message.MessageTypes.ClientId)
             {
                 if (string.IsNullOrWhiteSpace(e.message.messageText) || e.message.messageText == "0")
                 {
@@ -285,11 +285,11 @@ namespace Chat
                     e.client.receivedClientId = true;
                 }
             }
-            else if (e.message.messageType == 21) // Request for client version number
+            else if (e.message.messageType == Message.MessageTypes.RequestVersionNumber)
             {
                 network.BeginWrite(e.client, network.ComposeMessage(e.client, 0, 22, FrmHolder.applicationVersion, null));
             }
-            else if (e.message.messageType == 22) // Receive client version number
+            else if (e.message.messageType == Message.MessageTypes.ClientVersionNumber)
             {
                 e.client.applicationVersionNumber = (e.message.messageText);
                 e.client.receivedApplicationVersionNumber = true;
@@ -307,11 +307,11 @@ namespace Chat
                     }
                 }
             }
-            else if (e.message.messageType == 23) // Request for username
+            else if (e.message.messageType == Message.MessageTypes.RequestUsername)
             {
                 network.BeginWrite(e.client, network.ComposeMessage(e.client, 0, 24, FrmHolder.username, null));
             }
-            else if (e.message.messageType == 24) // Receive client username
+            else if (e.message.messageType == Message.MessageTypes.ClientUsername)
             {
                 string requestedUsername = e.message.messageText;
                 bool usernameAlreadyInUse = false;
@@ -333,27 +333,27 @@ namespace Chat
                     e.client.receivedUsername = true;
                 }
             }
-            else if (e.message.messageType == 25) // Request for client ID
+            else if (e.message.messageType == Message.MessageTypes.RequestClientId)
             {
                 string clientId = FrmHolder.clientId == 0 ? null : FrmHolder.clientId.ToString();
                 network.BeginWrite(e.client, network.ComposeMessage(e.client, 0, 20, clientId, null));
             }
-            else if (e.message.messageType == 26) // Receive servers minimum supported client application version number
+            else if (e.message.messageType == Message.MessageTypes.ServersMinimumSupportedClientVersionNumber)
             {
                 string serverMinimumSupportedClientApplicationVersionNumber = e.message.messageText;
                 e.client.serverMinimumSupportedClientApplicationVersionNumber = serverMinimumSupportedClientApplicationVersionNumber;
             }
-            else if (e.message.messageType == 27) // Receive servers maximum supported client application version number
+            else if (e.message.messageType == Message.MessageTypes.ServersMaximumSupportedClientVersionNumber)
             {
                 string serverMaximumSupportedClientApplicationVersionNumber = e.message.messageText;
                 e.client.serverMaximumSupportedClientApplicationVersionNumber = serverMaximumSupportedClientApplicationVersionNumber;
             }
-            else if (e.message.messageType == 28) // Receive whether the server supports client pre-release version numbers
+            else if (e.message.messageType == Message.MessageTypes.ServersPreReleaseSupport)
             {
                 bool serverSupportsClientPreReleaseVersionNumbers = e.message.messageText == "0" ? true : false;
                 e.client.serverSupportsClientPreReleaseAppplicationVersionNumber = serverSupportsClientPreReleaseVersionNumbers;
             }
-            else if (e.message.messageType == 29) // Receive whether the client application version number is less than, greater than, or compatible with the server
+            else if (e.message.messageType == Message.MessageTypes.ServerVersionNumberCompatibility)
             {
                 char clientApplicationNumberServerCompatibility = '=';
                 bool converted = Char.TryParse(e.message.messageText, out clientApplicationNumberServerCompatibility);
@@ -382,12 +382,12 @@ namespace Chat
                     BeginDisconnect();
                 }
             }
-            else if (e.message.messageType == 30) // Receive the server application version number
+            else if (e.message.messageType == Message.MessageTypes.ServerVersionNumber)
             {
                 string serverApplicationVersionNumber = e.message.messageText;
                 e.client.serverApplicationVersionNumber = serverApplicationVersionNumber;
             }
-            else if (e.message.messageType == 31) // Finished sending message queue
+            else if (e.message.messageType == Message.MessageTypes.FinishedSendingMessageQueue)
             {
                 e.client.receivingMessageQueue = false;
             }


### PR DESCRIPTION
Replaced message types from unsigned integers to an enumeration type so that the message type can be easily specified by name instead of a number.

Closes #42.