### PR TITLE
Develop bug #47 use message type enumeration for message send receive debugging

### DIFF
--- a/Chat/Network.cs
+++ b/Chat/Network.cs
@@ -618,7 +618,7 @@ namespace Chat
                 AddMessageToMessageListBySendPriority(clientStateObject.client.messagesToBeSent, clientStateObject.message, true);
             }
 #if DEBUG && messageSentUpdates
-                            if (message.messageType != 11)
+                            if (message.messageType != Message.MessageTypes.Heartbeat)
                             {
                                 string text;
                                 if (message.messageText != null)

--- a/Chat/Network.cs
+++ b/Chat/Network.cs
@@ -618,16 +618,16 @@ namespace Chat
                 AddMessageToMessageListBySendPriority(clientStateObject.client.messagesToBeSent, clientStateObject.message, true);
             }
 #if DEBUG && messageSentUpdates
-                            if (message.messageType != Message.MessageTypes.Heartbeat)
+                            if (clientStateObject.message.messageType != Message.MessageTypes.Heartbeat)
                             {
                                 string text;
-                                if (message.messageText != null)
+                                if (clientStateObject.message.messageText != null)
                                 {
-                                    text = $"[SENT] Type: {message.messageType}. ID: {message.messageId}. Text: {message.messageText}";
+                                    text = $"[SENT] Type: {clientStateObject.message.messageType}. ID: {clientStateObject.message.messageId}. Text: {clientStateObject.message.messageText}";
                                 }
                                 else
                                 {
-                                    text = $"[SENT] Type: {message.messageType}. ID: {message.messageId}";
+                                    text = $"[SENT] Type: {clientStateObject.message.messageType}. ID: {clientStateObject.message.messageId}";
                                 }
                                 PrintChatMessageEvent.Invoke(this, text);
                             }

--- a/Chat/frmChatScreen.cs
+++ b/Chat/frmChatScreen.cs
@@ -68,7 +68,7 @@ namespace Chat
                 }
             }
 #if DEBUG && messageReceivedUpdates
-            if (e.message.messageType != 11)
+            if (e.message.messageType != Message.MessageTypes.Heartbeat)
             {
                 if (e.message.messageText != null)
                 {


### PR DESCRIPTION
Replaces ints with their respective enumeration types in message send/receive debugging code.

Also references the client state object when accessing `message`, which should have been done before.

Closes #47.