### PR TITLE
Develop bug #49 Fix reading messages that are received as more or less bytes than a single message

### DIFF
--- a/Chat/Network.cs
+++ b/Chat/Network.cs
@@ -697,10 +697,15 @@ namespace Chat
                     {
                         clientStateObject.client.streamUnprocessedBytes.Position = clientStateObject.headerLength;
                         clientStateObject.client.streamUnprocessedBytes.Read(clientStateObject.messageBytes, 0, clientStateObject.messageBytes.Count());
+                        TruncateBytesPrecedingPositionInMemoryStream(clientStateObject.client);
                         ConvertLittleEndianToBigEndian(clientStateObject.messageBytes);
+                        Message receivedMessage = ComposeMessage(clientStateObject.client, clientStateObject.messageId.GetValueOrDefault(), clientStateObject.messageType, null, clientStateObject.messageBytes);
+                        MessageReceivedEvent.Invoke(this, new MessageReceivedEventArgs(clientStateObject.client, receivedMessage));
                     }
+                    else
+                    {
                     clientStateObject.client.streamUnprocessedBytes.Position = writePosition;
-                    TruncateBytesPrecedingPositionInMemoryStream(clientStateObject.client);
+                    }
                 }
                 Message receivedMessage = ComposeMessage(clientStateObject.client, clientStateObject.messageId.GetValueOrDefault(), clientStateObject.messageType, null, clientStateObject.messageBytes);
                 MessageReceivedEvent.Invoke(this, new MessageReceivedEventArgs(clientStateObject.client, receivedMessage));

--- a/Chat/Network.cs
+++ b/Chat/Network.cs
@@ -671,7 +671,7 @@ namespace Chat
             if (bytesRead > 0)
             {
                 clientStateObject.client.streamUnprocessedBytes.Write(clientStateObject.byteBuffer, 0, (int)bytesRead);
-                if (clientStateObject.client.streamUnprocessedBytes.Length >= clientStateObject.headerLength)
+                while (clientStateObject.client.streamUnprocessedBytes.Length >= clientStateObject.headerLength)
                 {
                     long writePosition = clientStateObject.client.streamUnprocessedBytes.Position;
                     if (clientStateObject.readHeader == false)
@@ -698,17 +698,17 @@ namespace Chat
                         clientStateObject.client.streamUnprocessedBytes.Position = clientStateObject.headerLength;
                         clientStateObject.client.streamUnprocessedBytes.Read(clientStateObject.messageBytes, 0, clientStateObject.messageBytes.Count());
                         TruncateBytesPrecedingPositionInMemoryStream(clientStateObject.client);
+                        clientStateObject.readHeader = false;
                         ConvertLittleEndianToBigEndian(clientStateObject.messageBytes);
                         Message receivedMessage = ComposeMessage(clientStateObject.client, clientStateObject.messageId.GetValueOrDefault(), clientStateObject.messageType, null, clientStateObject.messageBytes);
                         MessageReceivedEvent.Invoke(this, new MessageReceivedEventArgs(clientStateObject.client, receivedMessage));
                     }
                     else
                     {
-                    clientStateObject.client.streamUnprocessedBytes.Position = writePosition;
+                        clientStateObject.client.streamUnprocessedBytes.Position = writePosition;
+                        break;
                     }
                 }
-                Message receivedMessage = ComposeMessage(clientStateObject.client, clientStateObject.messageId.GetValueOrDefault(), clientStateObject.messageType, null, clientStateObject.messageBytes);
-                MessageReceivedEvent.Invoke(this, new MessageReceivedEventArgs(clientStateObject.client, receivedMessage));
                 BeginRead(clientStateObject.client);
             }
         }


### PR DESCRIPTION
Only handle a message if enough bytes for a complete message are received.

If more than one message might be available for processing, loop until all available messages are handled.

Closes #49.