### PR TITLE
Develop feat #52 move network object from chat screen to holder form

### DIFF
--- a/Chat/EventArgsData.cs
+++ b/Chat/EventArgsData.cs
@@ -4,7 +4,7 @@
     {
     }
 
-    class MessageReceivedEventArgs : EventArgs
+    public class MessageReceivedEventArgs : EventArgs
     {
         public Client client;
         public Message message;
@@ -16,7 +16,7 @@
         }
     }
 
-    class ShowMessageBoxEventArgs : EventArgs
+    public class ShowMessageBoxEventArgs : EventArgs
     {
         public string message;
         public string caption;

--- a/Chat/FrmHolder.cs
+++ b/Chat/FrmHolder.cs
@@ -9,6 +9,7 @@
         public static string applicationWindowText = "Chat";
 
         private FrmLoginScreen loginScreen;
+        public static Network network;
 
         public FrmHolder()
         {

--- a/Chat/Network.cs
+++ b/Chat/Network.cs
@@ -8,7 +8,7 @@ using System.Net.Sockets;
 
 namespace Chat
 {
-    class Network
+    public class Network
     {
         public X509Certificate2 x509Certificate;
         public string certificateName = "chatappserver.ddns.net";


### PR DESCRIPTION
In order to allow a connecting screen to be shown without the need to first open the chat screen, the network object used should be moved to the holder form.

Closes #52.