### PR TITLE
Disable nullable context warnings

### DIFF
--- a/Chat/Chat.csproj
+++ b/Chat/Chat.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
-	<Nullable>enable</Nullable>
+	  <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
 	  <ImplicitUsings>enable</ImplicitUsings>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>


### PR DESCRIPTION
A large amount of warnings is being generated by nullable context warnings being enabled, which might hide other, more important warnings.

Disable nullable context warnings.

Closes #55.