### PR TITLE
Develop feat #7 only show 'connected to (ip)' if connection is successful

### DIFF
--- a/Chat/Chat.csproj
+++ b/Chat/Chat.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
-	  <Nullable>disable</Nullable>
+	<Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
 	  <ImplicitUsings>enable</ImplicitUsings>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/Chat/EventArgsData.cs
+++ b/Chat/EventArgsData.cs
@@ -4,6 +4,30 @@
     {
     }
 
+    public class FirstConnectionAttemptResultEventArgs : EventArgs
+    {
+        public bool firstConnectionAttemptResult;
+        public string message;
+        public string caption;
+        public MessageBoxButtons messageBoxButtons;
+        public MessageBoxIcon messageBoxIcon;
+        public DialogResult dialogResult;
+
+        public FirstConnectionAttemptResultEventArgs(bool firstConnectionAttemptResult, string message, string caption, MessageBoxButtons messageBoxButtons, MessageBoxIcon messageBoxIcon)
+        {
+            this.firstConnectionAttemptResult = firstConnectionAttemptResult;
+            this.message = message;
+            this.caption = caption;
+            this.messageBoxButtons = messageBoxButtons;
+            this.messageBoxIcon = messageBoxIcon;
+        }
+
+        public FirstConnectionAttemptResultEventArgs(bool firstConnectionAttemptResult)
+        {
+            this.firstConnectionAttemptResult = firstConnectionAttemptResult;
+        }
+    }
+
     public class MessageReceivedEventArgs : EventArgs
     {
         public Client client;

--- a/Chat/FrmHolder.cs
+++ b/Chat/FrmHolder.cs
@@ -10,6 +10,7 @@
 
         private FrmLoginScreen loginScreen;
         public static Processing processing;
+        public static FrmChatScreen chatScreen;
 
         public FrmHolder()
         {

--- a/Chat/Network.cs
+++ b/Chat/Network.cs
@@ -7,6 +7,7 @@ namespace Chat
 {
     public class Network
     {
+        public event EventHandler<FirstConnectionAttemptResultEventArgs> FirstConnectionAttemptResultEvent;
         public event EventHandler<MessageReceivedEventArgs> MessageReceivedEvent;
         public event EventHandler<ShowMessageBoxEventArgs> ShowMessageBoxEvent;
         public event EventHandler<Client> AcceptTcpClientEvent;
@@ -304,6 +305,14 @@ namespace Chat
             client.streamUnprocessedBytes.Position = 0;
             client.streamUnprocessedBytes.Write(unprocessedBytes);
             client.streamUnprocessedBytes.SetLength(unprocessedBytes.Count());
+        }
+
+        private void InvokeFirstConnectionAttemptResultEvent(object sender, FirstConnectionAttemptResultEventArgs e)
+        {
+            if (FirstConnectionAttemptResultEvent != null)
+            {
+                FirstConnectionAttemptResultEvent.Invoke(sender, e);
+            }
         }
     }
 }

--- a/Chat/Processing.cs
+++ b/Chat/Processing.cs
@@ -11,6 +11,7 @@ namespace Chat
         private Network network;
 
         #region Event Handlers
+        public event EventHandler<FirstConnectionAttemptResultEventArgs> FirstConnectionAttemptResultEvent;
         public event EventHandler OpenMainMenuEvent;
         public event EventHandler<string> PrintChatMessageEvent;
         public event EventHandler<Client> HeartbeatTimeoutEvent;
@@ -56,6 +57,7 @@ namespace Chat
 
         private void SetNetworkEventHandlers()
         {
+            network.FirstConnectionAttemptResultEvent += OnFirstConnectionAttemptResult;
             network.MessageReceivedEvent += OnMessageReceived;
             network.ShowMessageBoxEvent += OnShowMessageBox;
             network.AcceptTcpClientEvent += OnAcceptTcpClient;
@@ -141,7 +143,6 @@ namespace Chat
 
             network.BeginConnect(client);
             StartHeartbeat();
-            InvokePrintChatMessageEvent(this, $"Connected to server on: {publicIp}"); //TODO: Only if succesfully connected - use acknowledgement
 
             while (cancellationToken.IsCancellationRequested == false)
             {
@@ -1172,6 +1173,14 @@ namespace Chat
         }
 
         #region Invoke Events
+        private void InvokeFirstConnectionAttemptResultEvent(object sender, FirstConnectionAttemptResultEventArgs e)
+        {
+            if (FirstConnectionAttemptResultEvent != null)
+            {
+                FirstConnectionAttemptResultEvent.Invoke(sender, e);
+            }
+        }
+
         private void InvokeOpenMainMenuEvent(object sender, EventArgs e)
         {
             if (OpenMainMenuEvent != null)
@@ -1220,6 +1229,11 @@ namespace Chat
             }
         }
         #endregion
+
+        private void OnFirstConnectionAttemptResult(object sender, FirstConnectionAttemptResultEventArgs e)
+        {
+            InvokeFirstConnectionAttemptResultEvent(this, e);
+        }
 
         private void OnShowMessageBox(object sender, ShowMessageBoxEventArgs showMessageBoxEventArgs)
         {

--- a/Chat/frmChatScreen.cs
+++ b/Chat/frmChatScreen.cs
@@ -17,7 +17,6 @@ namespace Chat
         public FrmChatScreen()
         {
             InitializeComponent();
-            FrmHolder.processing = new Processing();
             SetProcessingEventHandlers();
             SetFormEventHandlers();
             xlsvConnectedUsers.Columns[0].Width = xlsvConnectedUsers.Width - 5;

--- a/Chat/frmConnecting.Designer.cs
+++ b/Chat/frmConnecting.Designer.cs
@@ -1,0 +1,104 @@
+﻿namespace Chat
+{
+    partial class frmConnecting
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.xlblConnectingTo = new System.Windows.Forms.Label();
+            this.xlblServerName = new System.Windows.Forms.Label();
+            this.xtlpConnectingTo = new System.Windows.Forms.TableLayoutPanel();
+            this.xtlpConnectingTo.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // xlblConnectingTo
+            // 
+            this.xlblConnectingTo.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.xlblConnectingTo.AutoSize = true;
+            this.xlblConnectingTo.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.xlblConnectingTo.Location = new System.Drawing.Point(3, 0);
+            this.xlblConnectingTo.Name = "xlblConnectingTo";
+            this.xlblConnectingTo.Size = new System.Drawing.Size(794, 250);
+            this.xlblConnectingTo.TabIndex = 0;
+            this.xlblConnectingTo.Text = "Connecting to";
+            this.xlblConnectingTo.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
+            // 
+            // xlblServerName
+            // 
+            this.xlblServerName.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.xlblServerName.AutoSize = true;
+            this.xlblServerName.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.xlblServerName.Location = new System.Drawing.Point(3, 250);
+            this.xlblServerName.Name = "xlblServerName";
+            this.xlblServerName.Size = new System.Drawing.Size(794, 250);
+            this.xlblServerName.TabIndex = 1;
+            this.xlblServerName.Text = "Server Name";
+            this.xlblServerName.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // xtlpConnectingTo
+            // 
+            this.xtlpConnectingTo.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.xtlpConnectingTo.ColumnCount = 1;
+            this.xtlpConnectingTo.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.xtlpConnectingTo.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.xtlpConnectingTo.Controls.Add(this.xlblServerName, 0, 1);
+            this.xtlpConnectingTo.Controls.Add(this.xlblConnectingTo, 0, 0);
+            this.xtlpConnectingTo.Location = new System.Drawing.Point(50, 50);
+            this.xtlpConnectingTo.Name = "xtlpConnectingTo";
+            this.xtlpConnectingTo.RowCount = 2;
+            this.xtlpConnectingTo.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.xtlpConnectingTo.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.xtlpConnectingTo.Size = new System.Drawing.Size(800, 500);
+            this.xtlpConnectingTo.TabIndex = 2;
+            // 
+            // Connecting
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(900, 600);
+            this.Controls.Add(this.xtlpConnectingTo);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Name = "Connecting";
+            this.Text = "Connecting";
+            this.xtlpConnectingTo.ResumeLayout(false);
+            this.xtlpConnectingTo.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Label xlblConnectingTo;
+        private Label xlblServerName;
+        private TableLayoutPanel xtlpConnectingTo;
+    }
+}

--- a/Chat/frmConnecting.cs
+++ b/Chat/frmConnecting.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Chat
+{
+    public partial class frmConnecting : Form
+    {
+        public frmConnecting()
+        {
+            InitializeComponent();
+            SetIp(null);
+        }
+
+        public void SetIp(string serverName)
+        {
+            if (serverName == null)
+            {
+                xlblServerName.Text = FrmHolder.joinIP;
+            }
+            else
+            {
+                xlblServerName.Text = serverName;
+            }
+        }
+    }
+}

--- a/Chat/frmConnecting.resx
+++ b/Chat/frmConnecting.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Chat/frmLoginScreen.cs
+++ b/Chat/frmLoginScreen.cs
@@ -2,6 +2,9 @@
 {
     public partial class FrmLoginScreen : Form
     {
+        private delegate void FirstConnectionAttemptResultDelegate(FirstConnectionAttemptResultEventArgs firstConnectionAttemptResultEventArgs);
+        frmConnecting frmConnecting;
+
         public FrmLoginScreen()
         {
             InitializeComponent();
@@ -76,6 +79,17 @@
         private void xtbxUsername_TextChanged(object sender, EventArgs e)
         {
             xlblUsernameError.Hide();
+        }
+        private void OnFirstConnectionAttemptResult(object sender, FirstConnectionAttemptResultEventArgs firstConnectionAttemptResultEventArgs)
+        {
+            if (this.InvokeRequired)
+            {
+                this.BeginInvoke(new FirstConnectionAttemptResultDelegate(FirstConnectionAttemptResult), firstConnectionAttemptResultEventArgs);
+            }
+            else
+            {
+                FirstConnectionAttemptResult(firstConnectionAttemptResultEventArgs);
+            }
         }
     }
 }

--- a/Chat/frmLoginScreen.cs
+++ b/Chat/frmLoginScreen.cs
@@ -23,6 +23,7 @@
             {
                 FrmHolder.username = xtbxUsername.Text;
                 FrmHolder.hosting = true;
+                FrmHolder.processing = new Processing();
                 FrmChatScreen frmLoginScreen = new FrmChatScreen
                 {
                     MdiParent = this.ParentForm,
@@ -43,13 +44,14 @@
                 DialogResult dialogResult = frmEnterJoinIp.ShowDialog();
                 if (dialogResult == DialogResult.OK)
                 {
-                    FrmChatScreen frmChatScreen = new FrmChatScreen
+                    FrmHolder.processing = new Processing();
+                    FrmHolder.processing.FirstConnectionAttemptResultEvent += OnFirstConnectionAttemptResult;
+                    frmConnecting = new frmConnecting
                     {
                         MdiParent = this.ParentForm,
                         Dock = DockStyle.Fill
                     };
-                    frmChatScreen.Show();
-                    this.Close();
+                    frmConnecting.Show();
                 }
                 frmEnterJoinIp.Close();
             }
@@ -74,6 +76,27 @@
                 }
             }
             return true;
+        }
+
+        private void FirstConnectionAttemptResult(FirstConnectionAttemptResultEventArgs e)
+        {
+            if (e.firstConnectionAttemptResult == false)
+            {
+                if (e.message != null)
+                {
+                    MessageBox.Show(e.message, e.caption, e.messageBoxButtons, e.messageBoxIcon);
+                }
+            }
+            else
+            {
+                FrmHolder.chatScreen = new FrmChatScreen
+                {
+                    MdiParent = this.ParentForm,
+                    Dock = DockStyle.Fill
+                };
+                FrmHolder.chatScreen.Show();
+            }
+            frmConnecting.Close();
         }
 
         private void xtbxUsername_TextChanged(object sender, EventArgs e)


### PR DESCRIPTION
A connecting screen has been added. This shows the IP address of the server while connecting and opens the chat screen if connection is successful. If connection fails, then a warning is shown with a description of the failure and connecting screen closes.

Improvements can be made to this, such as adding a cancel button, an animated loading icon, reducing the time it takes for the connection to fail if the server can't be found etcetera.

Closes #7 