### PR TITLE
develop bug #8 Stop commands from showing to others

### DIFF
--- a/Chat/Processing.cs
+++ b/Chat/Processing.cs
@@ -900,7 +900,10 @@ namespace Chat
                 string[] parts = message.messageText.Split(' ', 2);
                 string username = parts[0];
                 string messageText = parts[1];
-                InvokePrintChatMessageEvent(this, $"{username}: {messageText}");
+                if (messageText[0] != '/')
+                {
+                    InvokePrintChatMessageEvent(this, $"{username}: {messageText}");
+                }
                 if (FrmHolder.hosting)
                 {
                     SendToAll(null, Message.MessageTypes.ChatMessage, message.messageText, null);


### PR DESCRIPTION
Commands shouldn't be shown to users in order to reduce message duplication - simply show the result of the command.

Don't send users commands as chat message.

Closes #8.