### PR TITLE
Develop bug #58 Catch IOExceptions on authentication

### DIFF
--- a/Chat/Network.cs
+++ b/Chat/Network.cs
@@ -64,7 +64,7 @@ namespace Chat
                     return;
                 }
             }
-            catch (AuthenticationException ex)
+            catch (Exception ex) when (ex is AuthenticationException || ex is IOException)
             {
                 client.sslStream.Close();
                 FrmHolder.processing.connectedClients.Remove(client);
@@ -106,7 +106,7 @@ namespace Chat
                     //MessageBoxEvent.Invoke(this, new ShowMessageBoxEventArgs("Unable to establish a secure connection to client.", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning));
                 }
             }
-            catch (AuthenticationException ex)
+            catch (Exception ex) when (ex is AuthenticationException || ex is IOException)
             {
                 client.sslStream.Close();
                 FrmHolder.processing.connectedClients.Remove(client);


### PR DESCRIPTION
An IOException may occur during authentication if the connection is dropped or otherwise fails ,and should be caught.

Catch IOExceptions on authentication.

Closes #58.