### PR TITLE
Main hotfix #70 Re-enable heartbeating

### DIFF
--- a/Chat/Chat.csproj
+++ b/Chat/Chat.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	  <!--Versioning MUST follow Semantic versioning 2.0.0: https://semver.org/spec/v2.0.0.html by Tom Preston-Werner. License (Creative Commons - CC BY 3.0): https://creativecommons.org/licenses/by/3.0/legalcode -->
 	  <!--For further information on how to use the below assembly versions, see https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ by Andrew Lock-->
-	  <VersionPrefix>0.2.0</VersionPrefix> <!--Main version number (e.g. '1.2.3')-->
+	  <VersionPrefix>0.2.1</VersionPrefix> <!--Main version number (e.g. '1.2.3')-->
 	  <VersionSuffix>alpha.1</VersionSuffix> <!--Version number suffix. May include version-specific release stage, (e.g. 'alpha', 'beta.1', 'rc.2') and may include build metadata, preceded by a '+' (e.g. '001', ) -->
 	  <Version></Version> <!--If unspecified, <VersionPrefix> and <VersionSuffix> are used-->
 	  <AssemblyVersion></AssemblyVersion> <!--Referenced by other APIs. Only change if introducing breaking-changes. If unspecified, <Version> is used-->

--- a/Chat/Processing.cs
+++ b/Chat/Processing.cs
@@ -375,7 +375,7 @@ namespace Chat
         {
             heartbeat.Interval = 1000;
             heartbeat.Elapsed += Heartbeat_Tick;
-            //heartbeat.Start();
+            heartbeat.Start();
         }
 
         private void StopHeartbeat()

--- a/Chat/VersionNumber.cs
+++ b/Chat/VersionNumber.cs
@@ -2,11 +2,11 @@
 {
     public static class VersionNumber
     {
-        public static string applicationVersion = "0.2.0-alpha"; //Format: [Major].[Minor].[Patch](optional:-[Pre-Release]). Follows semantic versioning 2.0.0. To use versions from the assembly (i.e. AssemblyInfo.cs): Application.ProductVersion;
-        public static string minimumSupportedClientVersion = "0.2.0-alpha"; //Format: [Major].[Minor].[Patch](optional:-[Pre-Release]). Follows semantic versioning 2.0.0. As a server, clients connecting must be of version equal to or greater than this.
+        public static string applicationVersion = "0.2.1-alpha"; //Format: [Major].[Minor].[Patch](optional:-[Pre-Release]). Follows semantic versioning 2.0.0. To use versions from the assembly (i.e. AssemblyInfo.cs): Application.ProductVersion;
+        public static string minimumSupportedClientVersion = "0.2.1-alpha"; //Format: [Major].[Minor].[Patch](optional:-[Pre-Release]). Follows semantic versioning 2.0.0. As a server, clients connecting must be of version equal to or greater than this.
         public static string maximumSupportedClientVersion = minimumSupportedClientVersion;
         public static bool allowClientPreRelease = true;
-        public static string minumumSupportedServerVersion = "0.2.0-alpha"; //Format: [Major].[Minor].[Patch](optional:-[Pre-Release]). Follows semantic versioning 2.0.0. As a client, servers connecting must be of version equal to or greater than this.
+        public static string minumumSupportedServerVersion = "0.2.1-alpha"; //Format: [Major].[Minor].[Patch](optional:-[Pre-Release]). Follows semantic versioning 2.0.0. As a client, servers connecting must be of version equal to or greater than this.
         public static string maximumSupportedServerVersion = minumumSupportedServerVersion;
         public static bool allowServerPreRelease = true;
 


### PR DESCRIPTION
Heartbeating should be enabled by default on all releases, but wasn't on 0.2.0.

Re-enables heartbeating.

Updates version number to 0.2.1.

Closes #70.